### PR TITLE
Fix: Team page image scaling

### DIFF
--- a/src/pages/Team.tsx
+++ b/src/pages/Team.tsx
@@ -366,7 +366,6 @@ const Team = () => {
         sx={{
           width: 140,
           height: 140,
-          mb: 2,
           borderRadius: "50%",
           overflow: "hidden",
           border: `4px solid ${alpha(theme.palette.primary.main, 0.3)}`,


### PR DESCRIPTION
# Changes

Based on #5 I have made a temporary fix for the team image scaling and the team member icons; review commits for details.